### PR TITLE
Update StopKeyword.voc

### DIFF
--- a/vocab/de-de/StopKeyword.voc
+++ b/vocab/de-de/StopKeyword.voc
@@ -1,3 +1,4 @@
+stopp
 Stop
 leise
 halt den Mund


### PR DESCRIPTION
On utterance "stop" the Google-STT (set to lang "de") returns "stopp" (which is the correct german spelling).