### PR TITLE
fix issue #1566

### DIFF
--- a/vocab/de-de/Stop.voc
+++ b/vocab/de-de/Stop.voc
@@ -1,4 +1,5 @@
-Stop
-Ruhe
-halt den Mund
+stop
+ruhe
+halt den mund
 sei leise
+ruhe bitte

--- a/vocab/en-us/Stop.voc
+++ b/vocab/en-us/Stop.voc
@@ -2,3 +2,5 @@ stop
 silence
 shut up
 be quiet
+please stop
+quiet please


### PR DESCRIPTION
fixes issue [#1566](https://github.com/MycroftAI/mycroft-core/issues/1566) 
> When Mycroft encounters any command with the word "stop," it simply isn't processed.

Make this a `FallbackSkill`, check in fallback-handler if utterance matches exactly phrase from `Stop.voc` and emit `mycroft.stop` accordingly.
